### PR TITLE
Removed requirement for entry-level author.

### DIFF
--- a/src/Atom/AtomFormatter.cs
+++ b/src/Atom/AtomFormatter.cs
@@ -296,26 +296,12 @@ namespace Microsoft.SyndicationFeed.Atom
                 }
             }
 
-            //
-            // author/contributor
-            bool hasAuthor = false;
-
             if (item.Contributors != null)
             {
                 foreach (var c in item.Contributors)
                 {
-                    if (c.RelationshipType == null || c.RelationshipType == AtomContributorTypes.Author)
-                    {
-                        hasAuthor = true;
-                    }
-
                     result.AddField(CreateContent(c));
                 }
-            }
-
-            if (!hasAuthor)
-            {
-                throw new ArgumentException("Author is required");
             }
 
             //


### PR DESCRIPTION
Fixes #43

The Atom spec does not require an author on every entry, if one is specified at the feed level. Since the AtomFormatter has no context beyond the specific element it is formatting, it does not have enough information to judge whether an author should be required or not.